### PR TITLE
Global update optimization

### DIFF
--- a/planet/emitter.js
+++ b/planet/emitter.js
@@ -10,6 +10,9 @@ console.log("\nEmitter is ready to emit for u ...");
 
 setInterval(function() {
   planetState.getState(function(state) {
-    io.emit('avatars-state', state);
+    io.emit('avatar-updates', state);
+
+    // clear between calculations so that the state only feeds me updates (rather than *all* avatars)
+    planetState.clearState();
   });
 }, 7777);

--- a/planet/emitter.js
+++ b/planet/emitter.js
@@ -15,4 +15,4 @@ setInterval(function() {
     // clear between calculations so that the state only feeds me updates (rather than *all* avatars)
     planetState.clearState();
   });
-}, 7777);
+}, 4000);

--- a/planet/planet-state.js
+++ b/planet/planet-state.js
@@ -9,6 +9,10 @@ module.exports.getState = function(callback) {
   calculateState(callback);
 };
 
+module.exports.clearState = function() {
+  redisClient.publish('planet', 'clearLocalState');
+};
+
 var calculateState = function(callback) {
   amalgamateAvatars(function(avatars) {
     if (!avatars) {
@@ -43,7 +47,7 @@ var calculateState = function(callback) {
 };
 
 var amalgamateAvatars = function(callback) {
-  redisClient.hgetall('planet:avatars', function(err, avatarMapsMap) {
+  redisClient.hgetall('planet:updated-avatars', function(err, avatarMapsMap) {
     if (!avatarMapsMap) {
       if (err) {
         console.log('err getting redis avatars: ');

--- a/planet/planet-state.js
+++ b/planet/planet-state.js
@@ -20,8 +20,6 @@ var calculateState = function(callback) {
       return;
     }
 
-    var planetAvatars = [];
-    var avatarsInDoors = {};
     var awakeCount = 0;
 
     for (var i = 0; i < avatars.length; i++) {
@@ -30,19 +28,9 @@ var calculateState = function(callback) {
       if (!avatar.sleeping) {
         awakeCount += 1;
       }
-
-      var doorID = avatar.currentDoor;
-      if (doorID) {
-        if (!avatarsInDoors[doorID]) {
-          avatarsInDoors[doorID] = [];
-        }
-        avatarsInDoors[doorID].push(avatar);
-      } else {
-        planetAvatars.push(avatar);
-      }
     }
 
-    callback({planet: planetAvatars, doors: avatarsInDoors, awakeCount: awakeCount});
+    callback({avatars: avatars, awakeCount: awakeCount});
   });
 };
 

--- a/planet/public/javascripts/api-tools.js
+++ b/planet/public/javascripts/api-tools.js
@@ -28,14 +28,14 @@ module.exports.createAvatar = function(avatarData, callback) {
   });
 };
 
-module.exports.getAvatarsInDoor = function(doorID, callback) {
-  if (!fetchSocket() || !doorID) {
-    callback({error: 'i aint gonna do it'});
+module.exports.getAvatars = function(doorID, callback) {
+  if (!fetchSocket()) {
+    callback({error: 'i aint gonna do it without a socket'});
     return;
   }
 
-  socket.emit('get-avatars-in-door', doorID, function(notes) {
-    callback(notes);
+  socket.emit('get-avatars-in-door', doorID, function(avatars) {
+    callback(avatars);
   });
 };
 

--- a/planet/public/javascripts/avatar-control-component.js
+++ b/planet/public/javascripts/avatar-control-component.js
@@ -42,10 +42,6 @@ AvatarControlComponent.prototype.postInit = function(options) {
     self.reactToPointerLock(self.cam.hasPointerlock);
   }, 2000);
   this.addInteractionGlue();
-
-  if (this.socket) {
-    this.socket.on('avatar-updates', this.handleAvatarUpdates.bind(this));
-  }
 };
 
 AvatarControlComponent.prototype.controlsOptions = function() {
@@ -224,21 +220,7 @@ AvatarControlComponent.prototype.mousemove = function(x, y, ev) {
   this.controls.mouseUpdate(movementX, movementY);
 };
 
-/** IO Response */
-
-AvatarControlComponent.prototype.handleAvatarUpdates = function(avatarUpdates) {
-  var awakeCount = avatarUpdates.awakeCount;
-  this.updateCohabitantCount(awakeCount);
-};
-
-AvatarControlComponent.prototype.updateCohabitantCount = function(count) {
-  var number = parseInt(count);
-  if (number !== undefined) {
-    var numberMinusSelf = Math.max(number - 1, 0);
-    var others = numberMinusSelf === 1 ? 'other' : 'others';
-    $('.avatar-count').text(numberMinusSelf + ' living ' + others);
-  }
-};
+/* Avatar Management */
 
 AvatarControlComponent.prototype.avatarUpdate = function(avatarData) {
   if (avatarData._id === this.avatar._id) {
@@ -249,7 +231,7 @@ AvatarControlComponent.prototype.avatarUpdate = function(avatarData) {
   if (!avatar) {
     avatar = new Avatar(avatarData);
     this.addSheenModel(avatar);
-    this.avatarsByName[avatar.name] = avatar;
+    this.avatarsByName[avatarData.name] = avatar;
   }
   else {
     avatar.updateFromModel(avatarData);
@@ -264,17 +246,17 @@ AvatarControlComponent.prototype.handleMyAvatars = function(updatedAvatars) {
   }
 };
 
-// called with avatars that should not be in here, but maybe used to be
-AvatarControlComponent.prototype.checkForMovedAvatars = function(updatedAvatars) {
-  for (var i = 0; i < updatedAvatars.length; i++) {
-    var avatarData = updatedAvatars[i];
+AvatarControlComponent.prototype.containsAvatar = function(avatarData) {
+  return this.avatarsByName[avatarData.name];
+};
 
-    var myAvatar = this.avatarsByName[avatarData.name];
-    if (myAvatar) {
-      // if we used to control it before this update, delete it
-      this.removeSheenModel(myAvatar);
-      delete this.avatarsByName[avatarData.name];
-    }
+AvatarControlComponent.prototype.removeAvatar = function(avatarData) {
+  var myAvatar = this.avatarsByName[avatarData.name];
+  if (myAvatar) {
+    // if we used to control it before this update, delete it
+    this.removeSheenModel(myAvatar);
+    delete this.avatarsByName[avatarData.name];
+    console.log('removing avatar with name: ' + avatarData.name);
   }
 };
 

--- a/planet/public/javascripts/become-avatar-component.js
+++ b/planet/public/javascripts/become-avatar-component.js
@@ -16,6 +16,7 @@ function BecomeAvatarComponent() {}
 BecomeAvatarComponent.prototype = Object.create(SceneComponent.prototype);
 
 BecomeAvatarComponent.prototype.postInit = function(options) {
+  this.identifier = 'becoming a man';
   var self = this;
 
   this.avatar = new Avatar({

--- a/planet/public/javascripts/general-planet-component.js
+++ b/planet/public/javascripts/general-planet-component.js
@@ -73,26 +73,6 @@ GeneralPlanetComponent.prototype.restore = function() {
   }
 };
 
-GeneralPlanetComponent.prototype.handleAvatarUpdates = function(avatarUpdates) {
-  AvatarControlComponent.prototype.handleAvatarUpdates.call(this, avatarUpdates);
-
-  var planetAvatars = avatarUpdates.planet;
-  this.handleMyAvatars(planetAvatars);
-
-  var avatarsWithinDoorsMap = avatarUpdates.doors;
-  var allDoorAvatars = [];
-  for (var doorID in avatarsWithinDoorsMap) {
-    if (avatarsWithinDoorsMap.hasOwnProperty(doorID)) {
-      var avatarsInSpecificDoor = avatarsWithinDoorsMap[doorID];
-      for (var i = 0; i < avatarsInSpecificDoor.length; i++) {
-        var avatar = avatarsInSpecificDoor[i];
-        allDoorAvatars.push(avatar);
-      }
-    }
-  }
-  this.checkForMovedAvatars(allDoorAvatars);
-};
-
 /** User Interaction */
 
 GeneralPlanetComponent.prototype.addInteractionGlue = function() {

--- a/planet/public/javascripts/general-planet-component.js
+++ b/planet/public/javascripts/general-planet-component.js
@@ -35,8 +35,15 @@ GeneralPlanetComponent.prototype.postInit = function(options) {
   this.doorSet = {};
 
   if (this.socket) {
+    // load every avatar that exists in outer-level planet (sleeping, awake) and add them to scene
+    apiTools.getAvatars(null, function(avatars) {
+      self.handleMyAvatars(avatars);
+    });
+
+    // when a new door is created, we add it to our world
     this.socket.on('door-created', this.addDoor.bind(this));
 
+    // get all the doors that exist, and put them into scene
     apiTools.getDoors({x: 0, y: 0, z: 0}, function(doors) {
       for (var i = 0; i < doors.length; i++) {
         self.addDoor(doors[i]);
@@ -66,11 +73,24 @@ GeneralPlanetComponent.prototype.restore = function() {
   }
 };
 
-GeneralPlanetComponent.prototype.updatedAvatarsState = function(avatarsState) {
-  AvatarControlComponent.prototype.updatedAvatarsState.call(this, avatarsState);
+GeneralPlanetComponent.prototype.handleAvatarUpdates = function(avatarUpdates) {
+  AvatarControlComponent.prototype.handleAvatarUpdates.call(this, avatarUpdates);
 
-  var planetAvatars = avatarsState.planet;
+  var planetAvatars = avatarUpdates.planet;
   this.handleMyAvatars(planetAvatars);
+
+  var avatarsWithinDoorsMap = avatarUpdates.doors;
+  var allDoorAvatars = [];
+  for (var doorID in avatarsWithinDoorsMap) {
+    if (avatarsWithinDoorsMap.hasOwnProperty(doorID)) {
+      var avatarsInSpecificDoor = avatarsWithinDoorsMap[doorID];
+      for (var i = 0; i < avatarsInSpecificDoor.length; i++) {
+        var avatar = avatarsInSpecificDoor[i];
+        allDoorAvatars.push(avatar);
+      }
+    }
+  }
+  this.checkForMovedAvatars(allDoorAvatars);
 };
 
 /** User Interaction */

--- a/planet/public/javascripts/general-planet-component.js
+++ b/planet/public/javascripts/general-planet-component.js
@@ -23,6 +23,7 @@ GeneralPlanetComponent.prototype = Object.create(AvatarControlComponent.prototyp
 
 GeneralPlanetComponent.prototype.postInit = function(options) {
   AvatarControlComponent.prototype.postInit.call(this, options);
+  this.identifier = 'outer planet';
 
   var self = this;
 
@@ -70,6 +71,9 @@ GeneralPlanetComponent.prototype.restore = function() {
 
   if (this.savedPosition) {
     this.avatar.moveTo(this.savedPosition);
+  }
+  else {
+    this.avatar.moveTo(0, 0, 0);
   }
 };
 

--- a/planet/public/javascripts/inner-door-component.js
+++ b/planet/public/javascripts/inner-door-component.js
@@ -33,12 +33,19 @@ InnerDoorComponent.prototype.postInit = function(options) {
   this.addMesh(this.room);
 
   if (this.socket) {
+    // when a new note is created in this room, add it in realtime
     this.socket.on('note-created', function(noteData) {
       if (noteData.door === self.door._id) {
         self.addNote(noteData);
       }
     });
 
+    // get all of the avatars currently in this door (asleep and awake) and add them to scene
+    apiTools.getAvatars(this.door._id, function(avatars) {
+      self.handleMyAvatars(avatars);
+    });
+
+    // get all the notes that are currently in this room and add them to the scene
     apiTools.getNotes(this.door._id, function(notes) {
       for (var i = 0; i < notes.length; i++) {
         self.addNote(notes[i]);
@@ -53,14 +60,17 @@ InnerDoorComponent.prototype.controlsOptions = function() {
   return options;
 };
 
-InnerDoorComponent.prototype.updatedAvatarsState = function(avatarsState) {
-  AvatarControlComponent.prototype.updatedAvatarsState.call(this, avatarsState);
+InnerDoorComponent.prototype.handleAvatarUpdates = function(avatarUpdates) {
+  AvatarControlComponent.prototype.handleAvatarUpdates.call(this, avatarUpdates);
 
-  var avatarsWithinDoors = avatarsState.doors;
+  var avatarsWithinDoors = avatarUpdates.doors;
   var avatarsInThisDoor = avatarsWithinDoors[this.door._id];
   if (!avatarsInThisDoor) avatarsInThisDoor = [];
 
   this.handleMyAvatars(avatarsInThisDoor);
+
+  var avatarsInPlanet = avatarUpdates.planet;
+  this.checkForMovedAvatars(avatarsInPlanet);
 };
 
 InnerDoorComponent.prototype.addInteractionGlue = function() {

--- a/planet/public/javascripts/inner-door-component.js
+++ b/planet/public/javascripts/inner-door-component.js
@@ -18,6 +18,7 @@ InnerDoorComponent.prototype = Object.create(AvatarControlComponent.prototype);
 
 InnerDoorComponent.prototype.postInit = function(options) {
   AvatarControlComponent.prototype.postInit.call(this, options);
+  this.identifier = 'inner door';
 
   var self = this;
 

--- a/planet/public/javascripts/inner-door-component.js
+++ b/planet/public/javascripts/inner-door-component.js
@@ -60,19 +60,6 @@ InnerDoorComponent.prototype.controlsOptions = function() {
   return options;
 };
 
-InnerDoorComponent.prototype.handleAvatarUpdates = function(avatarUpdates) {
-  AvatarControlComponent.prototype.handleAvatarUpdates.call(this, avatarUpdates);
-
-  var avatarsWithinDoors = avatarUpdates.doors;
-  var avatarsInThisDoor = avatarsWithinDoors[this.door._id];
-  if (!avatarsInThisDoor) avatarsInThisDoor = [];
-
-  this.handleMyAvatars(avatarsInThisDoor);
-
-  var avatarsInPlanet = avatarUpdates.planet;
-  this.checkForMovedAvatars(avatarsInPlanet);
-};
-
 InnerDoorComponent.prototype.addInteractionGlue = function() {
   AvatarControlComponent.prototype.addInteractionGlue.call(this);
 

--- a/planet/public/javascripts/main.js
+++ b/planet/public/javascripts/main.js
@@ -140,7 +140,7 @@ $(function() {
     state.frameCount += 1;
 
     // every few frames lets update our state to the server
-    if (state.frameCount % 120 === 0 && globals.playerAvatar) {
+    if (state.frameCount % 60 === 0 && state.mode !== BECOME_AVATAR_MODE) {
       updateMyAvatar();
     }
 

--- a/planet/public/javascripts/main.js
+++ b/planet/public/javascripts/main.js
@@ -206,8 +206,7 @@ $(function() {
     setGeneralPlanetHud();
 
     state.generalPlanetComponent.enterDoorCallback = function(door) {
-      state.generalPlanetComponent.removeObjects();
-      state.generalPlanetComponent.clean();
+      state.generalPlanetComponent.markFinished();
 
       startInsideDoorState(door);
     };

--- a/planet/public/javascripts/main.js
+++ b/planet/public/javascripts/main.js
@@ -18,19 +18,59 @@ var INSIDE_DOOR_MODE = 2;
 
 $(function() {
 
+  // trying to keep most mutable state in here
   var state = {
     frameCount: 0,
     mode: BECOME_AVATAR_MODE
   };
-  var socket = io(window.serverConfig.ioURL);
 
+  // set up my ole socket.IO listeners
+  var socket = io(window.serverConfig.ioURL);
+  socket.on('avatar-updates', function(avatarUpdates) {
+    updateCohabitantCount(avatarUpdates.awakeCount);
+
+    var planetComponent = state.generalPlanetComponent;
+    var doorComponent = state.currentInnerDoorComponent;
+    var updatedAvatars = avatarUpdates.avatars;
+
+    for (var i = 0; i < updatedAvatars.length; i++) {
+      var avatarData = updatedAvatars[i];
+
+      if (!avatarData.currentDoor) {
+        // its in the planet
+        if (planetComponent) {
+          // update the sucker
+          planetComponent.avatarUpdate(avatarData);
+        }
+
+        if (doorComponent && doorComponent.containsAvatar(avatarData)) {
+          doorComponent.removeAvatar(avatarData);
+        }
+      }
+      else {
+        // its in a door
+        if (doorComponent && doorComponent.door._id === avatarData.currentDoor) {
+          // its in my curent door
+          doorComponent.avatarUpdate(avatarData);
+        }
+
+        if (planetComponent && planetComponent.containsAvatar(avatarData)) {
+          // it used to be in planet .. cleanse it
+          planetComponent.removeAvatar(avatarData);
+        }
+      }
+    }
+  });
+
+  // anything in the DOM declared here
   var $huds = $('.bottom-hud, .top-hud');
   var $worldCoordinates = $('.world-coordinates');
   var $currentSpace = $('.current-space');
   var $questionMark = $('.question-mark');
   var $faq = $('.faq');
+  var $avatarCount = $('.avatar-count');
 
-  // create renderer
+  // create THREE.JS renderer
   var renderer;
   try {
     renderer = new THREE.WebGLRenderer({antialias: true});
@@ -48,7 +88,7 @@ $(function() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
 
-  // create scene
+  // create THREE.JS scene
   var scene = new THREE.Scene();
 
   // TODO: fog
@@ -67,16 +107,12 @@ $(function() {
   globals.scene = scene;
   globals.camera = cam;
 
-  if (config.testing) {
-    // do test stuff
-  }
-
   // start rendering
   cam.active = true;
   startBecomeAvatarState();
   render();
 
-  // react to  global shit
+  // react to  global DOM shit
   var showingFAQ = false;
   $questionMark.click(function() {
     toggleFaq();
@@ -202,6 +238,15 @@ $(function() {
 
       restoreGeneralPlanetState();
     };
+  }
+
+  function updateCohabitantCount(count) {
+    var number = parseInt(count);
+    if (number !== undefined) {
+      var numberMinusSelf = Math.max(number - 1, 0);
+      var others = numberMinusSelf === 1 ? 'other' : 'others';
+      $avatarCount.text(numberMinusSelf + ' living ' + others);
+    }
   }
 
   function setCurrentInstructions(text) {

--- a/planet/public/javascripts/model-loader.js
+++ b/planet/public/javascripts/model-loader.js
@@ -6,6 +6,7 @@ module.exports = function loadModel(name, callback) {
 
   if (cache[name]) {
     fetch(name, callback);
+    return;
   }
 
   var loader = new THREE.JSONLoader();

--- a/planet/public/javascripts/scene-component.js
+++ b/planet/public/javascripts/scene-component.js
@@ -43,6 +43,8 @@ SceneComponent.prototype.render = function() {
 };
 
 SceneComponent.prototype.restore = function() {
+  this.finished = false;
+
   for (var i = 0; i < this.renderObjects.length; i++) {
     this.renderObjects[i].addTo(this.scene);
   }
@@ -73,6 +75,12 @@ SceneComponent.prototype.markFinished = function() {
 };
 
 SceneComponent.prototype.addSheenModel = function(sheenModel, callback) {
+  if (this.finished) {
+    this.renderObjects.push(sheenModel);
+    if (callback) callback();
+    return;
+  }
+
   var self = this;
   sheenModel.addTo(this.scene, function() {
     self.renderObjects.push(sheenModel);
@@ -86,7 +94,7 @@ SceneComponent.prototype.removeSheenModel = function(sheenModel, callback) {
     var decrepitIndex = self.renderObjects.indexOf(sheenModel);
     console.log('decrip: ' + decrepitIndex);
     if (decrepitIndex >= 0) {
-      this.renderObjects.splice(decrepitIndex, 1); // remove the irrelevant object
+      self.renderObjects.splice(decrepitIndex, 1); // remove the irrelevant object
     }
 
     if (callback) callback();

--- a/planet/public/javascripts/scene-component.js
+++ b/planet/public/javascripts/scene-component.js
@@ -6,6 +6,8 @@ module.exports = SceneComponent;
 function SceneComponent() {}
 
 SceneComponent.prototype.init = function(scene, socket, cam, options) {
+  if (!options) options = {};
+
   this.scene = scene;
   this.socket = socket;
   this.cam = cam;
@@ -19,6 +21,7 @@ SceneComponent.prototype.init = function(scene, socket, cam, options) {
   $(window).resize(this.layout);
 
   this.frameCount = 0;
+  this.identifier = options.identifier || 'scene component';
 
   this.postInit(options);
 };
@@ -59,7 +62,7 @@ SceneComponent.prototype.removeObjects = function() {
     this.renderObjects[i].removeFrom(this.scene);
   }
 
-  for (var i = 0; i < this.additionalMeshes.length; i++) {
+  for (i = 0; i < this.additionalMeshes.length; i++) {
     this.scene.remove(this.additionalMeshes[i]);
   }
 };
@@ -92,7 +95,6 @@ SceneComponent.prototype.removeSheenModel = function(sheenModel, callback) {
   var self = this;
   sheenModel.removeFrom(this.scene, function() {
     var decrepitIndex = self.renderObjects.indexOf(sheenModel);
-    console.log('decrip: ' + decrepitIndex);
     if (decrepitIndex >= 0) {
       self.renderObjects.splice(decrepitIndex, 1); // remove the irrelevant object
     }
@@ -124,7 +126,7 @@ SceneComponent.prototype.showError = function(message, timeout) {
   setTimeout(function() {
     $error.hide();
   }, timeout);
-}
+};
 
 SceneComponent.prototype.preRender = function() {};
 SceneComponent.prototype.postRender = function() {};

--- a/planet/public/javascripts/sheen-model.js
+++ b/planet/public/javascripts/sheen-model.js
@@ -51,11 +51,15 @@ SheenModel.prototype.addTo = function(scene, callback) {
   }
 };
 
-SheenModel.prototype.removeFrom = function(scene) {
+SheenModel.prototype.removeFrom = function(scene, callback) {
   if (!this.hasLoadedMesh) return;
 
   for (var i = 0; i < this.meshes.length; i++) {
     scene.remove(this.meshes[i]);
+  }
+
+  if (callback) {
+    callback();
   }
 };
 


### PR DESCRIPTION
Migrate from a global state emission, to only updated avatars emission. Will save unnecessary computation and bandwidth on updating stagnant sleeping avatars.

Here were the notes I used in development and the tests I did:
1. When an avatar joins, it should fetch the global state with an api call and load all avatars (sleeping or awake) into the world.
2. When an io-server receives an avatar-update event, it should put that updated state in a map like it does today. However, that map should be reset every time emitter.js emits the state of all updated avatars to clients. This way, emittter.js will only ever be sending the state of avatars that have actually performed updates (rather than the same sleepy state of every avatar that has ever been created all of the time). This should be done via pub-sub.
3. Make sure that avatars entering rooms, leaving rooms, waking up, and going to sleep behaves correctly.
4. Make sure that when new avatars are created, that works correctly.
